### PR TITLE
Improve pattern matching

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -25,6 +25,22 @@ module Mseq = struct
     | List s ->
         List.length s
 
+  let is_length_at_least s i =
+    match s with
+    | Rope s ->
+        Rope.length_array s >= i
+    | List s ->
+        let rec work j s =
+          match (j, s) with
+          | 0, _ ->
+              true
+          | _, [] ->
+              false
+          | _, _ :: t ->
+              work (j - 1) t
+        in
+        work i s
+
   let concat s1 s2 =
     match (s1, s2) with
     | Rope s1, Rope s2 ->

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -52,6 +52,12 @@ module Mseq : sig
 
   (* Complexity:
    * rope (?): O(1) assuming OCaml's Array.length is O(1)
+   * list (?): O(i), where i is the provided length to compare with
+   *)
+  val is_length_at_least : 'a t -> int -> bool
+
+  (* Complexity:
+   * rope (?): O(1) assuming OCaml's Array.length is O(1)
    * list (?): O(n), where n is the length of the first argument
    *)
   val concat : 'a t -> 'a t -> 'a t

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -48,6 +48,10 @@ let _none = use OCamlAst in OTmConAppExt {ident = _noneName, args = []}
 let _if = use OCamlAst in lam cond. lam thn. lam els. _omatch_ cond [(ptrue_, thn), (pfalse_, els)]
 let _tuplet = use OCamlAst in lam pats. lam val. lam body. _omatch_ val [(OPatTuple {pats = pats}, body)]
 
+let _isLengthAtLeastName = intrinsicOpSeq "is_length_at_least"
+let _isLengthAtLeast = use OCamlAst in
+  appf2_ (OTmVarExt {ident = _isLengthAtLeastName})
+
 let _builtinNameMap : Map String Name =
   let builtinStrs =
     match unzip builtin with (strs, _) then
@@ -527,11 +531,16 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
       (wrap, postNames, midName)
     with (postWrap, postNames, midName) in
     let wrap = lam cont.
-      bind_
-        (nulet_ lenName (length_ (nvar_ targetName)))
-        (_if (lti_ (nvar_ lenName) (int_ minLen))
+      match postfix with [] then
+        _if (_isLengthAtLeast (nvar_ targetName) (int_ minLen))
+          (preWrap (postWrap cont))
           _none
-          (preWrap (postWrap cont))) in
+      else
+        bind_
+          (nulet_ lenName (length_ (nvar_ targetName)))
+          (_if (lti_ (nvar_ lenName) (int_ minLen))
+            _none
+            (preWrap (postWrap cont))) in
     let names = foldl mergeNames assocEmpty (concat preNames postNames) in
     let names = match middle with PName n then assocInsert {eq=nameEqSym} n midName names else names in
     (names, wrap)

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -452,22 +452,45 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
   | PatSeqTot {pats = pats} ->
     let genOne = lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env n pat with (names, innerWrap) then
-        let wrap = lam cont.
-          bind_
-            (nulet_ n (get_ (nvar_ targetName) (int_ i)))
-            (innerWrap cont)
-        in (names, wrap)
-      else never in
-    match unzip (mapi genOne pats) with (allNames, allWraps) then
+      match generatePat env n pat with (names, innerWrap) in
       let wrap = lam cont.
-        _if (eqi_ (length_ (nvar_ targetName)) (int_ (length pats)))
-          (foldr (lam f. lam v. f v) cont allWraps)
-          _none in
-      ( foldl (assocMergePreferRight {eq=nameEqSym}) assocEmpty allNames
-      , wrap
-      )
-    else never
+        bind_
+          (nulet_ n (get_ (nvar_ targetName) (int_ i)))
+          (innerWrap cont)
+      in (names, wrap) in
+    match unzip (mapi genOne pats) with (allNames, allWraps) in
+    let cond =
+      if null pats then _if (null_ (nvar_ targetName))
+      else _if (eqi_ (length_ (nvar_ targetName)) (int_ (length pats))) in
+    let wrap = lam cont.
+      cond
+        (foldr (lam f. lam v. f v) cont allWraps)
+        _none in
+    ( foldl (assocMergePreferRight {eq=nameEqSym}) assocEmpty allNames
+    , wrap
+    )
+  | PatSeqEdge {prefix = [head], middle = middle, postfix = []} ->
+    let apply = lam f. lam x. f x in
+    let headName = nameSym "_hd" in
+    let tailName = nameSym "_tl" in
+    match generatePat env headName head with (headNames, headWrap) in
+    match middle with PName mid then
+      let tl = PatNamed {ident = middle, info = NoInfo (), ty = tyunknown_} in
+      match generatePat env tailName tl with (tailNames, tailWrap) in
+      let wrap = lam cont.
+        _if (null_ (nvar_ targetName))
+          _none
+          (bindall_ [
+            nulet_ headName (head_ (nvar_ targetName)),
+            nulet_ tailName (tail_ (nvar_ targetName)),
+            headWrap (tailWrap cont)]) in
+      (assocMergePreferRight {eq=nameEqSym} headNames tailNames, wrap)
+    else
+      let wrap = lam cont.
+        _if (null_ (nvar_ targetName))
+          _none
+          (bind_ (nulet_ headName (head_ (nvar_ targetName))) (headWrap cont)) in
+      (headNames, wrap)
   | PatSeqEdge {prefix = prefix, middle = middle, postfix = postfix} ->
     let apply = lam f. lam x. f x in
     let mergeNames = assocMergePreferRight {eq=nameEqSym} in
@@ -478,28 +501,25 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
     let postName = nameSym "_postfix" in
     let genOne = lam targetName. lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env n pat with (names, innerWrap) then
+      match generatePat env n pat with (names, innerWrap) in
         let wrap = lam cont.
           bind_
             (nlet_ n tyunknown_ (get_ (nvar_ targetName) (int_ i)))
             (innerWrap cont)
-        in (names, wrap)
-      else never in
-    match unzip (mapi (genOne preName) prefix) with (preNames, preWraps) then
-      match unzip (mapi (genOne postName) postfix) with (postNames, postWraps) then
-        let names = foldl mergeNames assocEmpty (concat preNames postNames) in
-        let names = match middle with PName n then assocInsert {eq=nameEqSym} n midName names else names in
-        let wrap = lam cont.
-          _if (lti_ (length_ (nvar_ targetName)) (int_ minLen))
-            _none
-            (_tuplet [npvar_ preName, npvar_ tempName]
-              (splitat_ (nvar_ targetName) (int_ (length prefix)))
-              (_tuplet [npvar_ midName, npvar_ postName]
-                (splitat_ (nvar_ tempName) (subi_ (length_ (nvar_ tempName)) (int_ (length postfix))))
-                (foldr apply (foldr apply cont postWraps) preWraps))) in
-        (names, wrap)
-      else never
-    else never
+        in (names, wrap) in
+    match unzip (mapi (genOne preName) prefix) with (preNames, preWraps) in
+    match unzip (mapi (genOne postName) postfix) with (postNames, postWraps) in
+    let names = foldl mergeNames assocEmpty (concat preNames postNames) in
+    let names = match middle with PName n then assocInsert {eq=nameEqSym} n midName names else names in
+    let wrap = lam cont.
+      _if (lti_ (length_ (nvar_ targetName)) (int_ minLen))
+        _none
+        (_tuplet [npvar_ preName, npvar_ tempName]
+          (splitat_ (nvar_ targetName) (int_ (length prefix)))
+          (_tuplet [npvar_ midName, npvar_ postName]
+            (splitat_ (nvar_ tempName) (subi_ (length_ (nvar_ tempName)) (int_ (length postfix))))
+            (foldr apply (foldr apply cont postWraps) preWraps))) in
+    (names, wrap)
   | PatOr {lpat = lpat, rpat = rpat} ->
     match generatePat env targetName lpat with (lnames, lwrap) then
       match generatePat env targetName rpat with (rnames, rwrap) then

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -314,7 +314,7 @@ use TestLang in
 let debug = true in
 
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in


### PR DESCRIPTION
The following changes were made:
* Replaces uses of `match ... with ... then ... else never` with `match ... with ... in ...`
* Uses `null` instead of `length` for comparison for `PatSeqTot` of empty sequence
* Adds special-case treatment of the `[h] ++ t` pattern - checks `null s`, then applies `head s` and `tail s`
* Makes use of `is_length_at_least` from Boot-library (I didn't add it as an intrinsic, perhaps I should?) to avoid computing the full `length` of the sequence when postfix is empty in a `PatSeqEdge`.
* Fixes failing tests due to earlier merging of PRs.

If the postfix is non-empty in a `PatSeqEdge`, a linear behaviour for lists is unavoidable. But I didn't want to use `reverse`, since that would make Ropes worse, so I decided to leave them as is for now.